### PR TITLE
main finish function never called

### DIFF
--- a/lib/pomodoro-timer.coffee
+++ b/lib/pomodoro-timer.coffee
@@ -1,5 +1,7 @@
+events = require 'events'
+
 module.exports =
-class PomodoroTimer
+class PomodoroTimer extends events.EventEmitter
 
   TIME = 25 * 60 * 1000
 
@@ -32,7 +34,7 @@ class PomodoroTimer
   step: ->
     time = (TIME - (new Date() - @startTime)) / 1000
     if time <= 0
-      @finish()
+      @emit 'finished'
     else
       min = @zeroPadding(Math.floor(time / 60))
       sec = @zeroPadding(Math.floor(time % 60))

--- a/lib/pomodoro.coffee
+++ b/lib/pomodoro.coffee
@@ -14,6 +14,7 @@ module.exports =
     atom.workspaceView.command "pomodoro:abort", => @abort()
     @timer = new PomodoroTimer()
     @view = new PomodoroView(@timer)
+    @timer.on 'finished', => @finish()
     atom.workspaceView.statusBar.prependRight(@view)
 
   start: ->
@@ -29,7 +30,7 @@ module.exports =
   finish: ->
     console.log "pomodoro: finish"
     @timer.finish()
-    setTimeout ( => @exec(atom.config.get("pomodoro.pathToExecuteWithTimerFinish")) ), 2 * 1000
+    @exec atom.config.get("pomodoro.pathToExecuteWithTimerFinish")
 
   exec: (path) ->
     if path


### PR DESCRIPTION
the main `finish` function is never called.
thus the `@exec atom.config.get("pomodoro.pathToExecuteWithTimerFinish")` command is never run
